### PR TITLE
use non-commercial YQL for woeid lookups

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -28,9 +28,9 @@ url: http://weather.yahoo.com/search
   response.condition['text'] # => "Parcialmente Nublado"
   response.condition['country'] # => "Brasil"
 
-If you don't know your WOEID, you can leverage Yahoo's [GeoPlanet](http://developer.yahoo.com/geo/geoplanet) API by providing your Yahoo App ID. Then you can search by postal code, city/state, landmark, or any other combination allowed by their service.  Such as:
+If you don't know your WOEID, you can leverage Yahoo's [GeoPlanet](http://developer.yahoo.com/geo/geoplanet) API. You can search by postal code, city/state, landmark, or any other combination allowed by their service.  Such as:
 
-    client = Weatherman::Client.new( { :app_id => '[YOUR YAHOO APP ID]' } )
+    client = Weatherman::Client.new
 
     client.lookup_by_location('66061').condition['temp']
     client.lookup_by_location('olathe, ks').condition['temp']

--- a/lib/yahoo_weatherman.rb
+++ b/lib/yahoo_weatherman.rb
@@ -35,12 +35,9 @@ module Weatherman
     #
     #  +lang+: the language used in the response
     #
-    #  +app_id+: your yahoo app id (necessary for searching by location).
-    #
     def initialize(options = {})
       @options = options
       @uri = options[:url] || URI
-      @app_id = options[:app_id]
     end
     
     #
@@ -55,7 +52,7 @@ module Weatherman
     # Looks up weather by location.
     #
     def lookup_by_location(location)
-      lookup = WoeidLookup.new(@app_id)
+      lookup = WoeidLookup.new
       woeid = lookup.get_woeid(location)
       lookup_by_woeid(woeid)
     end

--- a/lib/yahoo_weatherman/woeid_lookup.rb
+++ b/lib/yahoo_weatherman/woeid_lookup.rb
@@ -3,21 +3,17 @@ require 'cgi'
 module Weatherman
   class WoeidLookup
 
-    def initialize(app_id)
-      @app_id = app_id
-    end
-
     def get_woeid(location)
       raw = get query_string(location)
       Nokogiri::HTML(raw).at_xpath('.//woeid').content
     rescue
       nil
     end
-    
+
     private
 
       def query_string(location)
-        "http://where.yahooapis.com/v1/places.q('#{::CGI.escape(location)}')?appid=#{@app_id}"
+        "http://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20geo.placefinder%20where%20text%3D%22#{::CGI.escape(location)}%22%20and%20gflags%3D%22R%22"
       end
 
       def get(url)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,11 +43,17 @@ module WoeidHelper
     File.open(File.dirname(__FILE__) + "/files/#{file}.xml").read
   end
 
-  def self.register_this_woeid_lookup_result(result, app_id, location)
-    FakeWeb.register_uri(:get, "http://where.yahooapis.com/v1/places.q('#{location}')?appid=#{app_id}", :body => result)
+  def self.register_this_woeid_lookup_result(result, location)
+    FakeWeb.register_uri(:get, lookup_uri(location), :body => result)
   end
 
-  def self.register_this_woeid_lookup_to_fail(app_id, location)
-    FakeWeb.register_uri(:get, "http://where.yahooapis.com/v1/places.q('#{location}')?appid=#{app_id}", :exception => Net::HTTPError)
+  def self.register_this_woeid_lookup_to_fail(location)
+    FakeWeb.register_uri(:get, lookup_uri(location), :exception => Net::HTTPError)
+  end
+
+  private
+
+  def self.lookup_uri(location)
+    "http://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20geo.placefinder%20where%20text%3D%22#{location}%22%20and%20gflags%3D%22R%22"
   end
 end

--- a/spec/yahoo_weatherman/woeid_lookup_spec.rb
+++ b/spec/yahoo_weatherman/woeid_lookup_spec.rb
@@ -2,14 +2,13 @@ require 'spec_helper'
 Dir[File.dirname(__FILE__) + '/directory/*.rb'].each {|file| require file }
 
 describe Weatherman::WoeidLookup do
-  describe "example with test_api_id and 66061" do 
+  describe "example with 66061" do 
     before do
-      @app_id = 'test_api_id'
       @location = '66061'
-      @lookup = Weatherman::WoeidLookup.new(@app_id)
+      @lookup = Weatherman::WoeidLookup.new
 
       xml_result = WoeidHelper.open_test_file('woeid_result_that_returns_12786745') 
-      WoeidHelper.register_this_woeid_lookup_result(xml_result, @app_id, @location)
+      WoeidHelper.register_this_woeid_lookup_result(xml_result, @location)
     end
 
     it "should retrieve the woeid" do
@@ -20,12 +19,11 @@ describe Weatherman::WoeidLookup do
 
   describe "example with another_api and 90210" do 
     before do
-      @app_id = 'another_api'
       @location = '90210'
-      @lookup = Weatherman::WoeidLookup.new(@app_id)
+      @lookup = Weatherman::WoeidLookup.new
 
       xml_result = WoeidHelper.open_test_file('woeid_result_that_returns_4729347') 
-      WoeidHelper.register_this_woeid_lookup_result(xml_result, @app_id, @location)
+      WoeidHelper.register_this_woeid_lookup_result(xml_result, @location)
     end
 
     it "should retrieve the woeid" do
@@ -34,28 +32,11 @@ describe Weatherman::WoeidLookup do
     end
   end
 
-  describe "invalid api key" do 
-    before do
-      @app_id = 'invalid_api'
-      @location = '12345'
-      @lookup = Weatherman::WoeidLookup.new(@app_id)
-
-      xml_result = WoeidHelper.open_test_file('woeid_result_for_invalid_app_id') 
-      WoeidHelper.register_this_woeid_lookup_result(xml_result, @app_id, @location)
-    end
-
-    it "should return nil" do
-      response = @lookup.get_woeid(@location)
-      response.should == nil
-    end
-  end
-
   describe "failed net request" do 
     before do
-      @app_id = 'net_failure'
       @location = '78902'
-      @lookup = Weatherman::WoeidLookup.new(@app_id)
-      WoeidHelper.register_this_woeid_lookup_to_fail @app_id, @location
+      @lookup = Weatherman::WoeidLookup.new
+      WoeidHelper.register_this_woeid_lookup_to_fail @location
     end
 
     it "should return nil" do
@@ -66,11 +47,10 @@ describe Weatherman::WoeidLookup do
 
   describe "request with spaces" do
     before do
-      @app_id = 'test_api_id'
-      @lookup = Weatherman::WoeidLookup.new(@app_id)
+      @lookup = Weatherman::WoeidLookup.new
 
       xml_result = WoeidHelper.open_test_file('woeid_result_that_returns_12786745')
-      WoeidHelper.register_this_woeid_lookup_result(xml_result, @app_id, "San+Francisco%2C+CA")
+      WoeidHelper.register_this_woeid_lookup_result(xml_result, "San+Francisco%2C+CA")
     end
 
     it "should retrieve the woeid" do

--- a/spec/yahoo_weatherman/yahoo_weatherman_spec.rb
+++ b/spec/yahoo_weatherman/yahoo_weatherman_spec.rb
@@ -15,13 +15,12 @@ describe Weatherman::Client do
   describe "#lookup_by_location" do
     describe "4729347 example" do
       it "should lookup by location" do
-        app_id = 'test_id'
         location = '78923'
 
         xml_result = WoeidHelper.open_test_file 'woeid_result_that_returns_4729347'
-        WoeidHelper.register_this_woeid_lookup_result xml_result, app_id, location
+        WoeidHelper.register_this_woeid_lookup_result xml_result, location
 
-        @client = Weatherman::Client.new( { :app_id => app_id } )
+        @client = Weatherman::Client.new()
         response = @client.lookup_by_location location
 
         response.should be_instance_of(Weatherman::Response)
@@ -30,13 +29,12 @@ describe Weatherman::Client do
 
     describe "12786745 example" do
       it "should lookup by location" do
-        app_id = 'apple'
         location = 'orange'
 
         xml_result = WoeidHelper.open_test_file 'woeid_result_that_returns_12786745'
-        WoeidHelper.register_this_woeid_lookup_result xml_result, app_id, location
+        WoeidHelper.register_this_woeid_lookup_result xml_result, location
 
-        @client = Weatherman::Client.new( { :app_id => app_id } )
+        @client = Weatherman::Client.new()
         response = @client.lookup_by_location location
 
         response.should be_instance_of(Weatherman::Response)


### PR DESCRIPTION
Note: I don't expect this to be merged immediately, but I wanted to start a conversation.

I started looking into Issue #6 for getting a woeid by lat/lng and didn't see an easy way to accomplish this with the woeid endpoint you were using (I later found it and replied to the issue).

Doing more digging, I found Yahoo has changed their API several times and seem to be pushing [Yahoo BOSS[(http://developer.yahoo.com/boss/geo/) now. One of the options is [Free non-commercial YQL lookups](http://developer.yahoo.com/boss/geo/docs/free_YQL.html) which allows you to do lookups by name, zip, lat/lng, and more and is pretty flexible.

So I took a stab at implementing that. The nice thing is that you don't need an APP ID and it is free. The downside is that you are limited to non-commercial use and 2000 requests per day.

Questions: What are your thoughts on using this endpoint? Is it worth replacing the default endpoint given the limitations? Is it worth implementing it as an alternate endpoint that is used if no APP ID is provided?

Thanks
