### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -45,6 +45,10 @@ Weatherman outputs the temperature as Celsius by default. To change this to Fahr
 
 To all the {nice folks}[http://github.com/dlt/yahoo_weatherman/graphs/contributors] who have contributed to this gem. :-)
 
+= Test
+
+Test the API on [RapidAPI](https://rapidapi.com/package/YahooWeatherAPI/functions?utm_source=YahooWeatherGitHub&utm_medium=button)
+
 = License
 
 (The MIT License)


### PR DESCRIPTION
I've added a link in your README to Yahoo's functions page in RapidAPI. I've done this for a few Yahoo Weather SDKs to help those who are reading the READMEs, understand and test the API before use.